### PR TITLE
#1140 Fixed illegal seek errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,5 +49,5 @@ RUN php composer.phar dump-autoload --optimize \
  && chown -R www-data: /var/www/rc-api
 
 EXPOSE 80
-CMD cd /var/container_init && ./init.sh && /usr/bin/supervisord -c /etc/supervisord.conf && /usr/sbin/apache2ctl -D FOREGROUND
+CMD cd /var/container_init && ./init.sh
 

--- a/conf/init.sh
+++ b/conf/init.sh
@@ -2,10 +2,12 @@
 
 #IMPORTANT!: Note that we do envsubst for all env variables for env.template. Take care with '$' characters in env.template, strings that start with $ will be treated like env vars.
 
-chown  www-data /var/log
-chown  www-data rc-api.log
+chown  www-data /var/log/
 #rc-admin
 envsubst < ./env.template > /var/www/rc-api/.env
 
 #log_files
 envsubst '${DEPLOYMENT_TYPE}' < ./log_files.yml.template > /etc/log_files.yml
+
+
+/usr/bin/supervisord -c /etc/supervisord.conf

--- a/conf/log_files.yml.template
+++ b/conf/log_files.yml.template
@@ -5,6 +5,8 @@ files:
     tag: ecs-rc-api-$DEPLOYMENT_TYPE-supervisor-supervisord.log
   - path: /var/log/supervisor/remote-syslog.log
     tag: ecs-rc-api-$DEPLOYMENT_TYPE-supervisor-remote-syslog.log
+  - path: /var/log/rc-api.log
+    tag: ecs-rc-api-$DEPLOYMENT_TYPE-elasticsearch.log
 destination:
   host: logs2.papertrailapp.com
   port: 39824

--- a/conf/log_files.yml.template
+++ b/conf/log_files.yml.template
@@ -1,16 +1,10 @@
 files:
-  - path: /var/log/apache2/access.log
-    tag: ecs-rc-api-$DEPLOYMENT_TYPE-apache2-access.log
-  - path: /var/log/apache2/error.log
-    tag: ecs-rc-api-$DEPLOYMENT_TYPE-apache2-error.log
-  - path: /var/log/apache2/other_vhosts_access.log
-    tag: ecs-rc-api-$DEPLOYMENT_TYPE-apache2-other_vhosts_access.log
+  - path: /var/log/supervisor/apache*.log
+    tag: ecs-rc-api-$DEPLOYMENT_TYPE-apache2.log
   - path: /var/log/supervisor/supervisord.log
     tag: ecs-rc-api-$DEPLOYMENT_TYPE-supervisor-supervisord.log
   - path: /var/log/supervisor/remote-syslog.log
     tag: ecs-rc-api-$DEPLOYMENT_TYPE-supervisor-remote-syslog.log
-  - path: /var/log/rc-api.log
-    tag: ecs-rc-api-$DEPLOYMENT_TYPE-elasticsearch.log
 destination:
   host: logs2.papertrailapp.com
   port: 39824

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -1,7 +1,14 @@
 [supervisord]
-nodaemon = false
+nodaemon = true
 logfile=/var/log/supervisor/supervisord.log
 childlogdir=/var/log/supervisor
+
+[program:apache2]
+user = root
+command=/usr/sbin/apache2ctl -D "FOREGROUND" -k start
+redirect_stderr=true
+redirect_stdout=true
+stderr_logfile=/var/log/apache.log
 
 [program:remote-syslog]
 command = /usr/local/bin/remote_syslog -D


### PR DESCRIPTION
The error messages were caused by the apache log.
The fix is actually a workaround, creating another log in the /var/log directory and sending them from there.