### PR TITLE
1145 fix errors from logs

### DIFF
--- a/app/Services/APIServices.php
+++ b/app/Services/APIServices.php
@@ -467,7 +467,7 @@ class APIServices extends Services
 
         $perPage = (isset($request['per_page']) && !empty($request['per_page'])) ? (integer)$request['per_page'] : self::SIZE;
         $perPage = ($perPage < 100) ? $perPage : 100;
-        $from = (isset($request['from']) && !empty($request['from'])) ? (integer)$request['from'] : self::FROM;
+        $from = (isset($request['from']) && !empty($request['from'] && (integer)$request['from']>-1 )) ? (integer)$request['from'] : self::FROM;
         $from = ($from < 9900) ? $from : 9900;
 
         $params['body']['size'] = $perPage;

--- a/app/Services/FulltextSearch.php
+++ b/app/Services/FulltextSearch.php
@@ -207,7 +207,7 @@ class FulltextSearch extends Services
 
         $perPage = (isset($request['per_page']) && !empty($request['per_page'])) ? (integer) $request['per_page'] : self::SIZE;
         $perPage = ($perPage < 100) ? $perPage : 100;
-        $from    = (isset($request['from']) && !empty($request['from'])) ? (integer) $request['from'] : self::FROM;
+        $from    = (isset($request['from']) && !empty($request['from'])) && (integer) $request['from']>-1? (integer) $request['from'] : self::FROM;
         $from    = ($from < 9900) ? $from : 9900;
 
         $params['body']['size'] = $perPage;
@@ -220,7 +220,7 @@ class FulltextSearch extends Services
         }
 
         $data         = $this->searchText($params, $type, $queryString, $lang);
-        $data['from'] = isset($request['from']) ? $request['from'] : self::FROM;
+        $data['from'] = isset($request['from']) and !empty($request['form']) and (integer)$request['form']>-1 ? $request['from'] : self::FROM;
 
         $data['per_page'] = (isset($request['per_page']) and !empty($request['per_page'])) ? $request['per_page'] : self::SIZE;
         if (isset($request['download']) && $request['download']) {

--- a/app/Services/FulltextSearch.php
+++ b/app/Services/FulltextSearch.php
@@ -154,19 +154,19 @@ class FulltextSearch extends Services
         ];
         if (isset($request['sort_by']) and !empty($request['sort_by'])) {
             if ($request['sort_by'] == "country") {
-                $params['body']['sort'][$lang.'.country_name']['order'] = (isset($request['order']) and !empty($request['order'])) ? $request['order'] : self::ORDER;
+                $params['body']['sort'][$lang.'.country_name']['order'] = $this->getSortOrder($request);
             }
             if ($request['sort_by'] == "year") {
-                $params['body']['sort'][$lang.'.signature_year']['order'] = (isset($request['order']) and !empty($request['order'])) ? $request['order'] : self::ORDER;
+                $params['body']['sort'][$lang.'.signature_year']['order'] = $this->getSortOrder($request);
             }
             if ($request['sort_by'] == "contract_name") {
-                $params['body']['sort'][$lang.'.contract_name.raw']['order'] = (isset($request['order']) and !empty($request['order'])) ? $request['order'] : self::ORDER;
+                $params['body']['sort'][$lang.'.contract_name.raw']['order'] = $this->getSortOrder($request);
             }
             if ($request['sort_by'] == "resource") {
-                $params['body']['sort'][$lang.'.resource_raw']['order'] = (isset($request['order']) and !empty($request['order'])) ? $request['order'] : self::ORDER;
+                $params['body']['sort'][$lang.'.resource_raw']['order'] = $this->getSortOrder($request);
             }
             if ($request['sort_by'] == "contract_type") {
-                $params['body']['sort'][$lang.'.contract_type']['order'] = (isset($request['order']) and !empty($request['order'])) ? $request['order'] : self::ORDER;
+                $params['body']['sort'][$lang.'.contract_type']['order'] = $this->getSortOrder($request);
             }
         }
 
@@ -565,6 +565,18 @@ class FulltextSearch extends Services
         }
 
         return $data;
+    }
+
+    /**
+     * @param $request
+     * @return string
+     */
+    private function getSortOrder($request)
+    {
+        return (isset($request['order']) and in_array(
+                $request['order'],
+                ['desc', 'asc']
+            )) ? $request['order'] : self::ORDER;
     }
 
 }

--- a/app/Services/FulltextSearch.php
+++ b/app/Services/FulltextSearch.php
@@ -83,10 +83,9 @@ class FulltextSearch extends Services
         if (isset($request['annotated']) and !empty($request['annotated']) and $request['annotated'] == 1) {
             $filters[] = [
                 "bool" => [
-                    "must_not" => [
-                        "missing" => [
-                            "field"     => "annotations_string.".$lang,
-                            "existence" => true,
+                    "must" => [
+                        "exists" => [
+                            "field"     => "annotations_string.".$lang
                         ],
                     ],
                 ],


### PR DESCRIPTION
When doing the migration to Elasticsearch 5, logs of requests made to Elasticsearch have been enabled.

Because of the above, a few error messages popped out that weren't visible before like passing a negative "from" parameter, or an invalid "order" parameter.

Another issue caught due to the logs was using an incorrect filter which is no longer supported in Elasticsearch 5 : "missing."