### PR TITLE
#1145 Fix error caused by the order parameter

### DIFF
--- a/app/Services/APIServices.php
+++ b/app/Services/APIServices.php
@@ -7,10 +7,7 @@
  */
 class APIServices extends Services
 {
-    /**
-     * string Sorting order default is ascending
-     */
-    const ORDER = "asc";
+
     /**
      * int Start from default is 0
      */
@@ -485,25 +482,19 @@ class APIServices extends Services
         if (isset($request['sort_by']) and !empty($request['sort_by'])) {
 
             if ($request['sort_by'] == 'country') {
-                $params['body']['sort'][$lang . '.country.name.raw']['order'] = (isset($request['order']) and in_array(
-                        $request['order'],
-                        ['desc', 'asc']
-                    )) ? $request['order'] : self::ORDER;
+                $params['body']['sort'][$lang . '.country.name.raw']['order'] = $this->getSortOrder($request);
             }
             if ($request['sort_by'] == 'year') {
-                $params['body']['sort'][$lang . '.signature_year']['order'] = (isset($request['order']) and in_array(
-                        $request['order'],
-                        ['desc', 'asc']
-                    )) ? $request['order'] : self::ORDER;
+                $params['body']['sort'][$lang . '.signature_year']['order'] = $this->getSortOrder($request);
             }
             if ($request['sort_by'] == 'contract_name') {
-                $params['body']['sort'][$lang . '.contract_name.raw']['order'] = (isset($request['order']) and !empty($request['order'])) ? $request['order'] : self::ORDER;
+                $params['body']['sort'][$lang . '.contract_name.raw']['order'] = $this->getSortOrder($request);
             }
             if ($request['sort_by'] == 'resource') {
-                $params['body']['sort'][$lang . '.resource']['order'] = (isset($request['order']) and !empty($request['order'])) ? $request['order'] : self::ORDER;
+                $params['body']['sort'][$lang . '.resource']['order'] = $this->getSortOrder($request);
             }
             if ($request['sort_by'] == 'contract_type') {
-                $params['body']['sort'][$lang . '.type_of_contract.raw']['order'] = (isset($request['order']) and !empty($request['order'])) ? $request['order'] : self::ORDER;
+                $params['body']['sort'][$lang . '.type_of_contract.raw']['order'] = $this->getSortOrder($request);
             }
         }
 

--- a/app/Services/APIServices.php
+++ b/app/Services/APIServices.php
@@ -391,7 +391,7 @@ class APIServices extends Services
 
         $params['body'] = [
             "_source" => [
-                "exclude" => [
+                "excludes" => [
                     $lang . ".updated_user_name",
                     $lang . ".updated_user_email",
                     $lang . ".updated_at",

--- a/app/Services/FulltextSearch.php
+++ b/app/Services/FulltextSearch.php
@@ -17,7 +17,6 @@ class FulltextSearch extends Services
 
     const FROM = 0;
     const SIZE = 25;
-    const ORDER = "asc";
     /**
      * @var APIRepositoryInterface
      */
@@ -565,18 +564,6 @@ class FulltextSearch extends Services
         }
 
         return $data;
-    }
-
-    /**
-     * @param $request
-     * @return string
-     */
-    private function getSortOrder($request)
-    {
-        return (isset($request['order']) and in_array(
-                $request['order'],
-                ['desc', 'asc']
-            )) ? $request['order'] : self::ORDER;
     }
 
 }

--- a/app/Services/Services.php
+++ b/app/Services/Services.php
@@ -10,6 +10,10 @@ use Monolog\Logger;
 class Services
 {
     /**
+     * string Sorting order default is ascending
+     */
+    const ORDER = "asc";
+    /**
      * @param index
      */
     public $index;
@@ -26,7 +30,7 @@ class Services
     {
         $hosts       = explode(",",env('ELASTICSEARCH_SERVER'));
         $this->index = env("INDEX");
-        $logger      = ClientBuilder::defaultLogger('/var/log/rc-api.log');
+        $logger      = ClientBuilder::defaultLogger('/var/log/rc-api.log', Logger::WARNING);
         $client      = ClientBuilder::create()->setHosts($hosts)->setLogger($logger);
         $this->api   = $client->build();
         $this->lang  = "en";
@@ -239,5 +243,17 @@ class Services
             return $field_value;
         }
         return [];
+    }
+
+    /**
+     * @param $request
+     * @return string
+     */
+    protected function getSortOrder($request)
+    {
+        return (isset($request['order']) and in_array(
+                $request['order'],
+                ['desc', 'asc']
+            )) ? $request['order'] : self::ORDER;
     }
 }


### PR DESCRIPTION
Prevented following error - from Papertrail:
```
Oct 14 23:04:54 d7a580a372fb ecs-rc-api-master-elasticsearch.log:  [2018-10-14 20:04:54] log.WARNING: Request Failure: {"method":"GET","uri":"https://portal69-34.resource-contracts-production5.2653858948.composedb.com:30435/rc_live_5/metadata/_search","headers":{"Host":["portal69-34.resource-contracts-production5.2653858948.composedb.com:30435"],"Content-Type":["application/json"],"Accept":["application/json"]},"HTTP code":400,"duration":0.008683,"error":"{\"error\":{\"root_cause\":[{\"type\":\"parsing_exception\",\"reason\":\"[field_sort] failed to parse field [order]\",\"line\":1,\"col\":114}],\"type\":\"parsing_exception\",\"reason\":\"[field_sort] failed to parse field [order]\",\"line\":1,\"col\":114,\"caused_by\":{\"type\":\"illegal_argument_exception\",\"reason\":\"No enum constant org.elasticsearch.search.sort.SortOrder.ASC'\"}},\"status\":400}"} []
Oct 14 23:04:54 d7a580a372fb ecs-rc-api-master-elasticsearch.log:  [2018-10-14 20:04:54] log.WARNING: Response ["{\"error\":{\"root_cause\":[{\"type\":\"parsing_exception\",\"reason\":\"[field_sort] failed to parse field [order]\",\"line\":1,\"col\":114}],\"type\":\"parsing_exception\",\"reason\":\"[field_sort] failed to parse field [order]\",\"line\":1,\"col\":114,\"caused_by\":{\"type\":\"illegal_argument_exception\",\"reason\":\"No enum constant org.elasticsearch.search.sort.SortOrder.ASC'\"}},\"status\":400}"] []
```
caused by the following request: `/contracts?country_code=&year&resource=&per_page=25&from=25&sort_by=resource&order=asc%27&all=0&download=&category=olc`

Prevented deprecation warning regarding `exclude` field.
