### PR TITLE
#1148 Disabled INFO and DEBUG logs for Elasticsearch.

### DIFF
--- a/app/Services/Services.php
+++ b/app/Services/Services.php
@@ -30,7 +30,7 @@ class Services
     {
         $hosts       = explode(",",env('ELASTICSEARCH_SERVER'));
         $this->index = env("INDEX");
-        $logger      = ClientBuilder::defaultLogger('/var/log/rc-api.log', Logger::DEBUG);
+        $logger      = ClientBuilder::defaultLogger('/var/log/rc-api.log', Logger::WARNING);
         $client      = ClientBuilder::create()->setHosts($hosts)->setLogger($logger);
         $this->api   = $client->build();
         $this->lang  = "en";


### PR DESCRIPTION
Elasticsearch requests generate too many logs with DEBUG level enabled. Set debug level to WARN.