### PR TITLE
Upgrade Elasticsearch client to version 6.x

### DIFF
--- a/app/Services/Services.php
+++ b/app/Services/Services.php
@@ -2,6 +2,7 @@
 
 use Elasticsearch\ClientBuilder;
 use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
 
 /**
  * Class Services
@@ -32,7 +33,8 @@ class Services
     {
         $hosts       = explode(",", env('ELASTICSEARCH_SERVER'));
         $this->index = env("INDEX");
-        $logger      = ClientBuilder::defaultLogger('/var/log/rc-api.log', Logger::WARNING);
+        $logger = new Logger('log');
+        $logger->pushHandler(new StreamHandler('/var/log/rc-api.log', Logger::WARNING));
         $client      = ClientBuilder::create()->setHosts($hosts)->setLogger($logger);
         $this->api   = $client->build();
         $this->lang  = "en";

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "yipl/rces",
   "type": "project",
   "require": {
-    "elasticsearch/elasticsearch": "~5.0",
+    "elasticsearch/elasticsearch": "~6.7.0",
     "league/route": "^1.1",
     "vlucas/phpdotenv": "^2.4",
     "symfony/http-foundation": "^2.6",

--- a/composer.lock
+++ b/composer.lock
@@ -1,36 +1,38 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2b62457004102237845fca9edc799e1b",
+    "content-hash": "78a7d1f0e927a119f1521ff73bff991e",
     "packages": [
         {
             "name": "elasticsearch/elasticsearch",
-            "version": "v5.3.2",
+            "version": "v6.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/elastic/elasticsearch-php.git",
-                "reference": "4b29a4121e790bbfe690d5ee77da348b62d48eb8"
+                "reference": "9ba89f905ebf699e72dacffa410331c7fecc8255"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elastic/elasticsearch-php/zipball/4b29a4121e790bbfe690d5ee77da348b62d48eb8",
-                "reference": "4b29a4121e790bbfe690d5ee77da348b62d48eb8",
+                "url": "https://api.github.com/repos/elastic/elasticsearch-php/zipball/9ba89f905ebf699e72dacffa410331c7fecc8255",
+                "reference": "9ba89f905ebf699e72dacffa410331c7fecc8255",
                 "shasum": ""
             },
             "require": {
+                "ext-json": ">=1.3.7",
                 "guzzlehttp/ringphp": "~1.0",
-                "php": "^5.6|^7.0",
+                "php": "^7.0",
                 "psr/log": "~1.0"
             },
             "require-dev": {
-                "cpliakas/git-wrapper": "~1.0",
+                "cpliakas/git-wrapper": "^1.7 || ^2.1",
                 "doctrine/inflector": "^1.1",
-                "mockery/mockery": "0.9.4",
-                "phpunit/phpunit": "^4.7|^5.4",
-                "sami/sami": "~3.2",
+                "mockery/mockery": "^1.2",
+                "phpstan/phpstan-shim": "^0.9 || ^0.11",
+                "phpunit/phpunit": "^5.7 || ^6.5",
+                "squizlabs/php_codesniffer": "^3.4",
                 "symfony/finder": "^2.8",
                 "symfony/yaml": "^2.8"
             },
@@ -51,6 +53,9 @@
             "authors": [
                 {
                     "name": "Zachary Tong"
+                },
+                {
+                    "name": "Enrico Zimuel"
                 }
             ],
             "description": "PHP Client for Elasticsearch",
@@ -59,7 +64,7 @@
                 "elasticsearch",
                 "search"
             ],
-            "time": "2017-11-08T17:04:47+00:00"
+            "time": "2019-07-19T14:48:24+00:00"
         },
         {
             "name": "guzzlehttp/ringphp",
@@ -110,6 +115,7 @@
                 }
             ],
             "description": "Provides a simple API and specification that abstracts away the details of HTTP into a single PHP function.",
+            "abandoned": true,
             "time": "2018-07-31T13:22:33+00:00"
         },
         {
@@ -160,6 +166,7 @@
                 "Guzzle",
                 "stream"
             ],
+            "abandoned": true,
             "time": "2014-10-12T19:18:40+00:00"
         },
         {
@@ -820,5 +827,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
## Why
We now run against a 5.x Elasticsearch deployment which has reached end of life. We risk not being able to fix ES server issues because of the lack of support.

Upgrading to 6.x would buy us some time to do the major refactoring needed to run 7.x .

## What
- [ ] the elasticsearch client is upgraded to version 6.x

## Notes
The 6.x client is backwards compatible to 5.x according to the change log. I also tested that with a custom rc-api container.