### PR TITLE
#1300 Fix group search last page crash

### DIFF
--- a/app/Services/FulltextSearch.php
+++ b/app/Services/FulltextSearch.php
@@ -379,12 +379,6 @@ class FulltextSearch extends Services
                 array_unique($contract_id_array['main_contract_ids'])
             );
             $contract_id_array['contract_ids']      = array_values(array_unique($contract_id_array['contract_ids']));
-
-            if (count($contract_id_array['main_contract_ids']) < $page_size) {
-                $params['body']['query']['bool']['must_not']['bool']['filter']['terms']['_id'] = $contract_id_array['contract_ids'];
-
-                return $this->getMainContracts($params, $contract_id_array);
-            }
         }
 
         return $contract_id_array;


### PR DESCRIPTION
NRGI/resourcecontracts.org#1300 No need to search for more main contracts since the method now only queries for main contracts and can't get less results than the page size unless we're on the last page.