### PR TITLE
Disable debug logging

### DIFF
--- a/app/Services/Services.php
+++ b/app/Services/Services.php
@@ -36,9 +36,9 @@ class Services
         $this->indices_prefix = env('INDICES_PREFIX');
 
         $log_level = Logger::WARNING;
-        if (env('APP_DEBUG') === 'true') {
-            $log_level = Logger::DEBUG;
-        }
+//        if (env('APP_DEBUG') === 'true') {
+//            $log_level = Logger::DEBUG;
+//        }
         $logger = new Logger('log');
         $logger->pushHandler(new StreamHandler('/var/log/rc-api.log', $log_level));
 


### PR DESCRIPTION
Stop debug logging because it is too verbose and eats up the available storage on Papertrail.